### PR TITLE
Bring snippets up to WordPress coding standards.

### DIFF
--- a/options-and-settings-pages/genesis-cpt-archive-metabox.php
+++ b/options-and-settings-pages/genesis-cpt-archive-metabox.php
@@ -1,39 +1,44 @@
 <?php
+
 /**
  * CMB2 Genesis CPT Archive Metabox
  *
  * To fetch these options, use `genesis_get_cpt_option()`, e.g.
- * 	// In CPT archive template:
- *  	if ( genesis_has_post_type_archive_support() ) {
- *  		$color = genesis_get_cpt_option( 'test_colorpicker' );
- *  	}
+ *    // In CPT archive template:
+ *    if ( genesis_has_post_type_archive_support() ) {
+ *        $color = genesis_get_cpt_option( 'test_colorpicker' );
+ *    }
  *
  * @version 0.1.0
  */
 class Myprefix_Genesis_CPT_Settings_Metabox {
 
 	/**
- 	 * Mmetabox id
- 	 * @var string
- 	 */
+	 * Metabox id
+	 *
+	 * @var string
+	 */
 	protected $metabox_id = 'genesis-cpt-archive-settings-metabox-%1$s';
 
 	/**
- 	 * CPT slug
- 	 * @var string
- 	 */
+	 * CPT slug
+	 *
+	 * @var string
+	 */
 	protected $post_type = '';
 
 	/**
- 	 * CPT slug
- 	 * @var string
- 	 */
+	 * CPT slug
+	 *
+	 * @var string
+	 */
 	protected $admin_hook = '%1$s_page_genesis-cpt-archive-%1$s';
 
 	/**
- 	 * Option key, and option page slug
- 	 * @var string
- 	 */
+	 * Option key, and option page slug
+	 *
+	 * @var string
+	 */
 	protected $key = 'genesis-cpt-archive-settings-%1$s';
 
 	/**
@@ -55,7 +60,7 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 	 *
 	 * @since  0.1.0
 	 *
-	 * @param  string $post_type Post type slug
+	 * @param  string $post_type Post type slug.
 	 *
 	 * @return Myprefix_Genesis_CPT_Settings_Metabox
 	 */
@@ -70,7 +75,10 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 
 	/**
 	 * Constructor
+	 *
 	 * @since 0.1.0
+	 *
+	 * @param string $post_type Post type slug.
 	 */
 	protected function __construct( $post_type ) {
 		$this->post_type  = $post_type;
@@ -81,6 +89,7 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 
 	/**
 	 * Initiate our hooks
+	 *
 	 * @since 0.1.0
 	 */
 	public function hooks() {
@@ -92,23 +101,28 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 
 	/**
 	 * Initiate admin hooks.
-	 * @since  0.1.0
+	 *
+	 * @since 0.1.0
 	 */
 	public function init() {
-		// Add custom archive support for CPT
+		// Add custom archive support for CPT.
 		add_post_type_support( $this->post_type, 'genesis-cpt-archives-settings' );
 	}
 
 	/**
 	 * Add admin hooks.
+	 *
 	 * @since 0.1.0
 	 */
 	public function admin_hooks() {
-		// Include CMB CSS in the head to avoid FOUC
+		// Include CMB CSS in the head to avoid FOUC.
 		add_action( "admin_print_styles-{$this->admin_hook}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
 
 		// Hook into the genesis cpt setttings save and add in the CMB2 sanitized values.
-		add_filter( "sanitize_option_genesis-cpt-archive-settings-{$this->post_type}", array( $this, 'add_sanitized_values' ), 999 );
+		add_filter( "sanitize_option_genesis-cpt-archive-settings-{$this->post_type}", array(
+			$this,
+			'add_sanitized_values',
+		), 999 );
 
 		// Hook up our Genesis metabox.
 		add_action( 'genesis_cpt_archives_settings_metaboxes', array( $this, 'add_meta_box' ) );
@@ -116,6 +130,7 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 
 	/**
 	 * Hook up our Genesis metabox.
+	 *
 	 * @since 0.1.0
 	 */
 	public function add_meta_box() {
@@ -132,7 +147,8 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 
 	/**
 	 * Output our Genesis metabox.
-	 * @since  0.1.0
+	 *
+	 * @since 0.1.0
 	 */
 	public function output_metabox() {
 		$cmb = $this->init_metabox();
@@ -144,7 +160,8 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param  array $new_value Array of values for the setting.
+	 * @param array $new_value Array of values for the setting.
+	 *
 	 * @return array Updated array of values for the setting.
 	 */
 	public function add_sanitized_values( $new_value ) {
@@ -163,7 +180,7 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 	/**
 	 * Register our Genesis metabox and return the CMB2 instance.
 	 *
-	 * @since  0.1.0
+	 * @since 0.1.0
 	 *
 	 * @return CMB2 instance.
 	 */
@@ -181,14 +198,13 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 			// 'priority'     => 'low', // Defaults to 'high'.
 			'object_types' => array( $this->admin_hook ),
 			'show_on'      => array(
-				// These are important, don't remove
+				// These are important, don't remove.
 				'key'   => 'options-page',
-				'value' => array( $this->key, )
+				'value' => array( $this->key ),
 			),
 		), $this->key, 'options-page' );
 
-		// Set our CMB2 fields
-
+		// Set our CMB2 fields.
 		$this->cmb->add_field( array(
 			'name' => __( 'Test Text', 'myprefix' ),
 			'desc' => __( 'field description (optional)', 'myprefix' ),
@@ -210,12 +226,17 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 
 	/**
 	 * Public getter method for retrieving protected/private variables
-	 * @since  0.1.0
-	 * @param  string  $field Field to retrieve
-	 * @return mixed          Field value or exception is thrown
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string $field Field to retrieve.
+	 *
+	 * @throws Exception Throws an exception if the field is invalid.
+	 *
+	 * @return mixed Field value or exception is thrown
 	 */
 	public function __get( $field ) {
-		// Allowed fields to retrieve
+		// Allowed fields to retrieve.
 		if ( 'cmb' === $field ) {
 			return $this->init_metabox();
 		}
@@ -232,9 +253,9 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 /**
  * Helper function to get/return the Myprefix_Genesis_CPT_Settings_Metabox object.
  *
- * @since  0.1.0
+ * @since 0.1.0
  *
- * @param  string $post_type Post type slug
+ * @param string $post_type Post type slug.
  *
  * @return Myprefix_Genesis_CPT_Settings_Metabox object
  */
@@ -242,5 +263,5 @@ function myprefix_genesis_cpt_settings( $post_type ) {
 	return Myprefix_Genesis_CPT_Settings_Metabox::get_instance( $post_type );
 }
 
-// Get it started
-// myprefix_genesis_cpt_settings( 'custom-post-type-slug' );
+// Get it started.
+//myprefix_genesis_cpt_settings( 'custom-post-type-slug' );

--- a/options-and-settings-pages/genesis-cpt-archive-metabox.php
+++ b/options-and-settings-pages/genesis-cpt-archive-metabox.php
@@ -119,10 +119,7 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 		add_action( "admin_print_styles-{$this->admin_hook}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
 
 		// Hook into the genesis cpt setttings save and add in the CMB2 sanitized values.
-		add_filter( "sanitize_option_genesis-cpt-archive-settings-{$this->post_type}", array(
-			$this,
-			'add_sanitized_values',
-		), 999 );
+		add_filter( "sanitize_option_genesis-cpt-archive-settings-{$this->post_type}", array( $this, 'add_sanitized_values' ), 999 );
 
 		// Hook up our Genesis metabox.
 		add_action( 'genesis_cpt_archives_settings_metaboxes', array( $this, 'add_meta_box' ) );
@@ -264,4 +261,4 @@ function myprefix_genesis_cpt_settings( $post_type ) {
 }
 
 // Get it started.
-//myprefix_genesis_cpt_settings( 'custom-post-type-slug' );
+// myprefix_genesis_cpt_settings( 'custom-post-type-slug' );

--- a/options-and-settings-pages/genesis-cpt-archive-metabox.php
+++ b/options-and-settings-pages/genesis-cpt-archive-metabox.php
@@ -118,7 +118,7 @@ class Myprefix_Genesis_CPT_Settings_Metabox {
 		// Include CMB CSS in the head to avoid FOUC.
 		add_action( "admin_print_styles-{$this->admin_hook}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
 
-		// Hook into the genesis cpt setttings save and add in the CMB2 sanitized values.
+		// Hook into the genesis cpt settings save and add in the CMB2 sanitized values.
 		add_filter( "sanitize_option_genesis-cpt-archive-settings-{$this->post_type}", array( $this, 'add_sanitized_values' ), 999 );
 
 		// Hook up our Genesis metabox.

--- a/options-and-settings-pages/genesis-settings-metabox.php
+++ b/options-and-settings-pages/genesis-settings-metabox.php
@@ -1,37 +1,41 @@
 <?php
+
 /**
  * CMB2 Genesis Settings Metabox
  *
  * To fetch these options, use `genesis_get_option()`, e.g.
- *
- * 	$color = genesis_get_option( 'test_colorpicker' );
+ *      $color = genesis_get_option( 'test_colorpicker' );
  *
  * @version 0.1.0
  */
 class Myprefix_Genesis_Settings_Metabox {
 
 	/**
- 	 * Option key. Could maybe be 'genesis-seo-settings', or other section?
- 	 * @var string
- 	 */
+	 * Option key. Could maybe be 'genesis-seo-settings', or other section?
+	 *
+	 * @var string
+	 */
 	protected $key = 'genesis-settings';
 
 	/**
- 	 * The admin page slug.
- 	 * @var string
- 	 */
+	 * The admin page slug.
+	 *
+	 * @var string
+	 */
 	protected $admin_page = 'genesis';
 
 	/**
- 	 * Options page metabox id
- 	 * @var string
- 	 */
+	 * Options page metabox id
+	 *
+	 * @var string
+	 */
 	protected $metabox_id = 'myprefix_genesis_settings';
 
 	/**
- 	 * Admin page hook
- 	 * @var string
- 	 */
+	 * Admin page hook
+	 *
+	 * @var string
+	 */
 	protected $admin_hook = 'toplevel_page_genesis';
 
 	/**
@@ -64,6 +68,7 @@ class Myprefix_Genesis_Settings_Metabox {
 
 	/**
 	 * Constructor
+	 *
 	 * @since 0.1.0
 	 */
 	protected function __construct() {
@@ -71,6 +76,7 @@ class Myprefix_Genesis_Settings_Metabox {
 
 	/**
 	 * Initiate our hooks
+	 *
 	 * @since 0.1.0
 	 */
 	public function hooks() {
@@ -80,10 +86,11 @@ class Myprefix_Genesis_Settings_Metabox {
 
 	/**
 	 * Add menu options page
+	 *
 	 * @since 0.1.0
 	 */
 	public function admin_hooks() {
-		// Include CMB CSS in the head to avoid FOUC
+		// Include CMB CSS in the head to avoid FOUC.
 		add_action( "admin_print_styles-{$this->admin_hook}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
 
 		// Hook into the genesis cpt setttings save and add in the CMB2 sanitized values.
@@ -96,6 +103,7 @@ class Myprefix_Genesis_Settings_Metabox {
 
 	/**
 	 * Hook up our Genesis metabox.
+	 *
 	 * @since 0.1.0
 	 */
 	public function add_meta_box() {
@@ -112,7 +120,8 @@ class Myprefix_Genesis_Settings_Metabox {
 
 	/**
 	 * Output our Genesis metabox.
-	 * @since  0.1.0
+	 *
+	 * @since 0.1.0
 	 */
 	public function output_metabox() {
 		$cmb = $this->init_metabox();
@@ -124,7 +133,8 @@ class Myprefix_Genesis_Settings_Metabox {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param  array $new_value Array of values for the setting.
+	 * @param array $new_value Array of values for the setting.
+	 *
 	 * @return array Updated array of values for the setting.
 	 */
 	public function add_sanitized_values( $new_value ) {
@@ -153,7 +163,7 @@ class Myprefix_Genesis_Settings_Metabox {
 		}
 
 		$this->cmb = cmb2_get_metabox( array(
-			'id'         => $this->metabox_id,
+			'id'           => $this->metabox_id,
 			'title'        => __( 'I\'m a Genesis Settings CMB2 metabox', 'myprefix' ),
 			'hookup'       => false, // We'll handle ourselves. (add_sanitized_values())
 			'cmb_styles'   => false, // We'll handle ourselves. (admin_hooks())
@@ -161,14 +171,13 @@ class Myprefix_Genesis_Settings_Metabox {
 			// 'priority'     => 'low', // Defaults to 'high'.
 			'object_types' => array( $this->admin_hook ),
 			'show_on'      => array(
-				// These are important, don't remove
+				// These are important, don't remove.
 				'key'   => 'options-page',
-				'value' => array( $this->key, )
+				'value' => array( $this->key ),
 			),
 		), $this->key, 'options-page' );
 
-		// Set our CMB2 fields
-
+		// Set our CMB2 fields.
 		$this->cmb->add_field( array(
 			'name' => __( 'Test Text', 'myprefix' ),
 			'desc' => __( 'field description (optional)', 'myprefix' ),
@@ -189,17 +198,22 @@ class Myprefix_Genesis_Settings_Metabox {
 	}
 
 	/**
-	 * Public getter method for retrieving protected/private variables
-	 * @since  0.1.0
-	 * @param  string  $field Field to retrieve
-	 * @return mixed          Field value or exception is thrown
+	 * Public getter method for retrieving protected/private variables.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string $field Field to retrieve.
+	 *
+	 * @throws Exception Throws an exception if the field is invalid.
+	 *
+	 * @return mixed Field value or exception is thrown
 	 */
 	public function __get( $field ) {
 		if ( 'cmb' === $field ) {
 			return $this->init_metabox();
 		}
 
-		// Allowed fields to retrieve
+		// Allowed fields to retrieve.
 		if ( in_array( $field, array( 'key', 'admin_page', 'metabox_id', 'admin_hook' ), true ) ) {
 			return $this->{$field};
 		}
@@ -211,12 +225,14 @@ class Myprefix_Genesis_Settings_Metabox {
 
 /**
  * Helper function to get/return the Myprefix_Genesis_Settings_Metabox object
- * @since  0.1.0
+ *
+ * @since 0.1.0
+ *
  * @return Myprefix_Genesis_Settings_Metabox object
  */
 function myprefix_genesis_settings_metabox() {
 	return Myprefix_Genesis_Settings_Metabox::get_instance();
 }
 
-// Get it started
+// Get it started.
 myprefix_genesis_settings_metabox();


### PR DESCRIPTION
Just some minor formatting adjustments to bring the snippets inline with [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards).