### PR TITLE
Theme options page from printing styles to enqueuing

### DIFF
--- a/options-and-settings-pages/theme-options-cmb.php
+++ b/options-and-settings-pages/theme-options-cmb.php
@@ -67,6 +67,7 @@ class Myprefix_Admin {
 		add_action( 'admin_init', array( $this, 'init' ) );
 		add_action( 'admin_menu', array( $this, 'add_options_page' ) );
 		add_action( 'cmb2_admin_init', array( $this, 'add_options_page_metabox' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_options_page_styles' ) );
 	}
 
 
@@ -84,10 +85,19 @@ class Myprefix_Admin {
 	 */
 	public function add_options_page() {
 		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->key, array( $this, 'admin_page_display' ) );
-
-		// Include CMB CSS in the head to avoid FOUC
-		add_action( "admin_print_styles-{$this->options_page}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
 	}
+
+	/**
+	 * Enqueue options page styles
+	 * @since 0.1.0
+	 */
+	public function add_options_page_styles( $hook ) {
+		if ( $hook != $this->options_page ) {
+			return;
+		}
+		CMB2_hookup::enqueue_cmb_css();
+	}
+
 
 	/**
 	 * Admin page markup. Mostly handled by CMB2


### PR DESCRIPTION
I wanted to update the theme options page from using `admin_print_styles` to `admin_enqueue_styles`. The [Codex](https://codex.wordpress.org/Plugin_API/Action_Reference/admin_print_styles) mentions that it is not advised to print styles, so I'm not sure if it applies here.