### PR TITLE
:bug: Restore repeatable limits functionality

### DIFF
--- a/javascript/limit-number-of-repeat-fields.php
+++ b/javascript/limit-number-of-repeat-fields.php
@@ -43,11 +43,11 @@ function js_limit_field_repeat( $post_id, $cmb ) {
 		};
 
 		var disableAdder = function() {
-			$repeatWrap.parents( '.cmb-repeat.table-layout' ).find('.cmb-add-row-button.button').prop( 'disabled', true );
+			$repeatWrap.parents( '.cmb-repeat.table-layout' ).find('.cmb-add-row-button').prop( 'disabled', true );
 		};
 
 		var enableAdder = function() {
-			$repeatWrap.parents( '.cmb-repeat.table-layout' ).find('.cmb-add-row-button.button').prop( 'disabled', false );
+			$repeatWrap.parents( '.cmb-repeat.table-layout' ).find('.cmb-add-row-button').prop( 'disabled', false );
 		};
 
 		$fieldTable

--- a/javascript/limit-number-of-repeat-groups.php
+++ b/javascript/limit-number-of-repeat-groups.php
@@ -62,11 +62,11 @@ function js_limit_group_repeat( $post_id, $cmb ) {
 		};
 
 		var disableAdder = function() {
-			$fieldGroupTable.find('.cmb-add-group-row.button').prop( 'disabled', true );
+			$fieldGroupTable.find('.cmb-add-group-row').prop( 'disabled', true );
 		};
 
 		var enableAdder = function() {
-			$fieldGroupTable.find('.cmb-add-group-row.button').prop( 'disabled', false );
+			$fieldGroupTable.find('.cmb-add-group-row').prop( 'disabled', false );
 		};
 
 		$fieldGroupTable


### PR DESCRIPTION
Addresses https://github.com/CMB2/CMB2-Snippet-Library/issues/83

After upgrading from CMB2 2.2.1 => 2.6.0, repeatable row limits stopped working.

This is because a classname `button` has been removed, which meant the logic was never firing for disableAdder and enableAdder .

Removing the `.button` qualifying classname restores the repeatable functionality and row limits now work as expected.